### PR TITLE
Save Parquet file : OK

### DIFF
--- a/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA-checkpoint.ipynb
@@ -13,7 +13,14 @@
    "id": "0a6e368b-be9e-4195-b2ab-5f3eebcdcc12",
    "metadata": {},
    "source": [
-    "Ce script a pour objectif d'extraire les offres d'emploi mises à disposition par l'API de France Travail et de l'API ADZUNA et de les stocker dans un fichier (CSV) en local ainsi qu'une sauvegarde dans une BDD PostgreSQL en local."
+    "Ce script a pour objectif :\n",
+    "- d'extraire les offres d'emploi mises à disposition par :\n",
+    "  <br> _ l'API de **France Travail**\n",
+    "  <br>_ de l'API **ADZUNA**\n",
+    "- les stocker dans :\n",
+    "  <br> _ un fichier (**CSV**) en local\n",
+    "  <br> _ un fichier (**Parquet**) en local\n",
+    "  <br> _ dans une **BDD PostgreSQL** en local."
    ]
   },
   {
@@ -26,8 +33,9 @@
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API France Travail\n",
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API Adzuna\n",
     "2. Une fois les offres trouvées, vérification et suppression des doublons.\n",
-    "3. Une sauvegarde en local des offres sont stockées dans un fichier (CSV).\n",
-    "4. Une sauvegarde dans une base de données PostgreSQL est également effectuée en local."
+    "3. Une sauvegarde en local des offres sont stockées dans un fichier (**CSV**).\n",
+    "4. Une sauvegarde en local des offres sont stockées dans un fichier (**Parquet**).\n",
+    "5. Une sauvegarde dans une base de données **PostgreSQL** est également effectuée en local."
    ]
   },
   {
@@ -63,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 122,
    "id": "59e94172-c17e-4a12-9519-d1b26cd600df",
    "metadata": {},
    "outputs": [],
@@ -73,6 +81,7 @@
     "import json\n",
     "import pandas as pd\n",
     "import os\n",
+    "from datetime import datetime\n",
     "import hashlib\n",
     "from sqlalchemy import create_engine, text"
    ]
@@ -95,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 123,
    "id": "17e18cf1-1961-4200-9bb9-497ce803db59",
    "metadata": {},
    "outputs": [],
@@ -128,13 +137,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 124,
    "id": "8c47f4fc-a8ce-482c-ae6d-250061c5682d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# ---------------------------\n",
-    "# PARAMETRES\n",
+    "# PARAMETRES DE RECHERCHE\n",
     "# ---------------------------\n",
     "\n",
     "# Paramètres de recherche\n",
@@ -151,6 +160,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1f8c2baf-0c81-4879-9cbb-7d3cad0f33a0",
+   "metadata": {},
+   "source": [
+    "### Paramètres de sauvegarde"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "id": "13daef8d-56fc-4538-994e-cecd5e78e67e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ---------------------------\n",
+    "# PARAMETRES DE SAUVEGARDE\n",
+    "# ---------------------------\n",
+    "# Répertoires\n",
+    "CSV_DIR = \"../data/csv\"\n",
+    "PARQUET_DIR = \"../data/parquet\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "59b50db3-037e-4050-b095-393fd8ca5aa1",
    "metadata": {},
    "source": [
@@ -159,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 126,
    "id": "5eb9b1d6-25f8-496c-8422-ba1185aee138",
    "metadata": {},
    "outputs": [],
@@ -190,7 +222,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 127,
    "id": "e82e7838-3f2b-4058-95fe-465efefdbc5c",
    "metadata": {},
    "outputs": [],
@@ -251,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 128,
    "id": "86633fe9-b12a-4e55-9a0a-e63ccba9d994",
    "metadata": {},
    "outputs": [],
@@ -315,7 +347,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 129,
    "id": "98da7cdb-9465-4684-957e-041bfe9c26a5",
    "metadata": {},
    "outputs": [],
@@ -345,7 +377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 130,
    "id": "ad547c1c-d524-4cad-8bbf-67afaafddb35",
    "metadata": {},
    "outputs": [],
@@ -383,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 131,
    "id": "77e3c4fc-d709-4a7e-bfb6-a32651541e7d",
    "metadata": {},
    "outputs": [],
@@ -403,6 +435,58 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fd75112a-913c-4cc2-bdfd-f5a320ac2e9d",
+   "metadata": {},
+   "source": [
+    "### Sauvegarde CSV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "id": "75d0bd1a-552d-4f1a-a5d5-6c71331c54cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Sauvegarde Parquet ---\n",
+    "def save_to_csv(df):\n",
+    "    if df.empty:\n",
+    "        return\n",
+    "    os.makedirs(CSV_DIR, exist_ok=True)\n",
+    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
+    "    path_csv = os.path.join(CSV_DIR, f\"{today}_offres.csv\")\n",
+    "    df.to_csv(path_csv, index=False,encoding=\"utf-8\")\n",
+    "    print(f\"✅ Sauvegardé dans {path_csv}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e4c69b5-e661-49b9-be53-abe6835a3a74",
+   "metadata": {},
+   "source": [
+    "### Sauvegarde Parquet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "id": "0b972c51-3307-49aa-a409-21b662763b9f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# --- Sauvegarde Parquet ---\n",
+    "def save_to_parquet(df):\n",
+    "    if df.empty:\n",
+    "        return\n",
+    "    os.makedirs(PARQUET_DIR, exist_ok=True)\n",
+    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
+    "    path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
+    "    df.to_parquet(path_parquet, index=False)\n",
+    "    print(f\"✅ Sauvegardé dans {path_parquet}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "54cdda02-d6b6-40a2-bfac-934fc24cf646",
    "metadata": {},
    "source": [
@@ -411,7 +495,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 134,
    "id": "fb6f8148-0086-47ea-b620-5d32c006c054",
    "metadata": {},
    "outputs": [],
@@ -440,15 +524,16 @@
     "\n",
     "    print(\"Affichage Extract offres France Travail...\")\n",
     "    df = pd.DataFrame(jobs_clean)\n",
-    "    display(df.shape)\n",
-    "    display(df.head(3))\n",
     "\n",
     "    # Export vers CSV\n",
-    "    path = \"../data/raw_data/\"\n",
-    "    file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
+    "    print(\"💾 Sauvegarde en CSV...\")\n",
+    "    save_to_csv(df)\n",
+    "\n",
+    "    # Export vers Parquet\n",
+    "    print(\"💾 Sauvegarde en Parquet...\")\n",
+    "    save_to_parquet(df)\n",
     "    \n",
-    "    df.to_csv(path + file_name, index=False, encoding=\"utf-8\")\n",
-    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {file_name} ✅\")\n",
+    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {CSV_DIR} et {PARQUET_DIR} ✅\")\n",
     "\n",
     "    # Connexion DB\n",
     "    print(\"Connexion à la base PostgreSQL...\")\n",
@@ -459,22 +544,25 @@
     "\n",
     "    print(\"💾 Sauvegarde en base PostgreSQL...\")\n",
     "    save_to_postgres(df, engine)\n",
-    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")"
+    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")\n",
+    "\n",
+    "    # Affichage extract offres\n",
+    "    display(df.shape)\n",
+    "    display(df.head(3))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 135,
    "id": "2de560b5-c04e-4118-9662-7069e1da4bf8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# # Chargement depuis CSV\n",
-    "# path = \"../data/raw_data/\"\n",
-    "# file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
-    "\n",
-    "# df = pd.read_csv(path+file_name)\n",
-    "# df.head(2)"
+    "# today = datetime.now().strftime(\"%Y-%m-%d\")\n",
+    "# path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
+    "# df = pd.read_parquet(path_parquet)\n",
+    "# df.head()"
    ]
   },
   {
@@ -487,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 136,
    "id": "ff03fb25-913a-46ea-a784-b7f5f54e9f61",
    "metadata": {},
    "outputs": [
@@ -499,15 +587,23 @@
       "Récupération des offres France Travail...\n",
       "Récupération des offres Adzuna...\n",
       "Fusion et déduplication...\n",
-      "Nombre d'offres d'emploi avant déduplication : 1185\n",
-      "Nombre d'offres d'emploi après déduplication : 1183\n",
-      "Affichage Extract offres France Travail...\n"
+      "Nombre d'offres d'emploi avant déduplication : 1183\n",
+      "Nombre d'offres d'emploi après déduplication : 1181\n",
+      "Affichage Extract offres France Travail...\n",
+      "💾 Sauvegarde en CSV...\n",
+      "✅ Sauvegardé dans ../data/csv/2025-09-17_offres.csv\n",
+      "💾 Sauvegarde en Parquet...\n",
+      "✅ Sauvegardé dans ../data/parquet/2025-09-17_offres.parquet\n",
+      "1181 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
+      "Connexion à la base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(1183, 12)"
+       "(1181, 12)"
       ]
      },
      "metadata": {},
@@ -552,6 +648,21 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>France Travail</td>\n",
+       "      <td>197XHCS</td>\n",
+       "      <td>DATA ANALYST/SCIENTIST(H/F)</td>\n",
+       "      <td>En tant que Data Analyst - Data Scientist, vou...</td>\n",
+       "      <td>INFOBAM</td>\n",
+       "      <td>972 - LE LAMENTIN</td>\n",
+       "      <td>14.615411</td>\n",
+       "      <td>-61.003361</td>\n",
+       "      <td>CDI</td>\n",
+       "      <td>2025-09-16T18:29:39.856Z</td>\n",
+       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
+       "      <td>Gestion d'installations informatiques</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>France Travail</td>\n",
        "      <td>197TNXM</td>\n",
        "      <td>Data Analyst ETL / SI Junior - H/F (H/F)</td>\n",
        "      <td>Empreinte est une société Française qui crée, ...</td>\n",
@@ -565,7 +676,7 @@
        "      <td>Fabrication de vêtements de dessous</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
+       "      <th>2</th>\n",
        "      <td>France Travail</td>\n",
        "      <td>197NKZD</td>\n",
        "      <td>Consultant Data confirmé - Data Analyst H/F</td>\n",
@@ -579,45 +690,30 @@
        "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
        "      <td>Conseil en systèmes et logiciels informatiques</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>France Travail</td>\n",
-       "      <td>197PLRS</td>\n",
-       "      <td>Data Analyst (h/f)</td>\n",
-       "      <td>Adecco recherche pour l'un de ses clients, une...</td>\n",
-       "      <td>ADECCO FRANCE</td>\n",
-       "      <td>13 - Marignane</td>\n",
-       "      <td>43.407483</td>\n",
-       "      <td>5.255358</td>\n",
-       "      <td>Intérim - 12 Mois</td>\n",
-       "      <td>2025-09-09T16:27:22.779Z</td>\n",
-       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
-       "      <td>Activités des agences de travail temporaire</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "           Source       id                                        Titre  \\\n",
-       "0  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
-       "1  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
-       "2  France Travail  197PLRS                           Data Analyst (h/f)   \n",
+       "0  France Travail  197XHCS                  DATA ANALYST/SCIENTIST(H/F)   \n",
+       "1  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
+       "2  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
        "\n",
-       "                                         Description     Entreprise  \\\n",
-       "0  Empreinte est une société Française qui crée, ...   EMPREINTE SA   \n",
-       "1  Nous recherchons un(e) Consultant(e) Data conf...        EFFIDIC   \n",
-       "2  Adecco recherche pour l'un de ses clients, une...  ADECCO FRANCE   \n",
+       "                                         Description    Entreprise  \\\n",
+       "0  En tant que Data Analyst - Data Scientist, vou...       INFOBAM   \n",
+       "1  Empreinte est une société Française qui crée, ...  EMPREINTE SA   \n",
+       "2  Nous recherchons un(e) Consultant(e) Data conf...       EFFIDIC   \n",
        "\n",
-       "             Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
-       "0      29 - BREST  48.414003  -4.491985                  CDI   \n",
-       "1    49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
-       "2  13 - Marignane  43.407483   5.255358    Intérim - 12 Mois   \n",
+       "                Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
+       "0  972 - LE LAMENTIN  14.615411 -61.003361                  CDI   \n",
+       "1         29 - BREST  48.414003  -4.491985                  CDI   \n",
+       "2       49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
        "\n",
        "           Date_publication  \\\n",
-       "0  2025-09-12T17:46:57.887Z   \n",
-       "1  2025-09-09T09:24:40.097Z   \n",
-       "2  2025-09-09T16:27:22.779Z   \n",
+       "0  2025-09-16T18:29:39.856Z   \n",
+       "1  2025-09-12T17:46:57.887Z   \n",
+       "2  2025-09-09T09:24:40.097Z   \n",
        "\n",
        "                                                 URL  \\\n",
        "0  https://candidat.francetravail.fr/offres/reche...   \n",
@@ -625,23 +721,13 @@
        "2  https://candidat.francetravail.fr/offres/reche...   \n",
        "\n",
        "                                Secteur_activites  \n",
-       "0             Fabrication de vêtements de dessous  \n",
-       "1  Conseil en systèmes et logiciels informatiques  \n",
-       "2     Activités des agences de travail temporaire  "
+       "0           Gestion d'installations informatiques  \n",
+       "1             Fabrication de vêtements de dessous  \n",
+       "2  Conseil en systèmes et logiciels informatiques  "
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "1183 offres uniques exportées dans offres_emploi_france_travail_adzuna.csv ✅\n",
-      "Connexion à la base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
-     ]
     }
    ],
    "source": [

--- a/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA_BACKUP-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA_BACKUP-checkpoint.ipynb
@@ -13,14 +13,7 @@
    "id": "0a6e368b-be9e-4195-b2ab-5f3eebcdcc12",
    "metadata": {},
    "source": [
-    "Ce script a pour objectif :\n",
-    "- d'extraire les offres d'emploi mises à disposition par :\n",
-    "  <br> _ l'API de **France Travail**\n",
-    "  <br>_ de l'API **ADZUNA**\n",
-    "- les stocker dans :\n",
-    "  <br> _ un fichier (**CSV**) en local\n",
-    "  <br> _ un fichier (**Parquet**) en local\n",
-    "  <br> _ dans une **BDD PostgreSQL** en local."
+    "Ce script a pour objectif d'extraire les offres d'emploi mises à disposition par l'API de France Travail et de l'API ADZUNA et de les stocker dans un fichier (CSV) en local ainsi qu'une sauvegarde dans une BDD PostgreSQL en local."
    ]
   },
   {
@@ -33,9 +26,8 @@
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API France Travail\n",
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API Adzuna\n",
     "2. Une fois les offres trouvées, vérification et suppression des doublons.\n",
-    "3. Une sauvegarde en local des offres sont stockées dans un fichier (**CSV**).\n",
-    "4. Une sauvegarde en local des offres sont stockées dans un fichier (**Parquet**).\n",
-    "5. Une sauvegarde dans une base de données **PostgreSQL** est également effectuée en local."
+    "3. Une sauvegarde en local des offres sont stockées dans un fichier (CSV).\n",
+    "4. Une sauvegarde dans une base de données PostgreSQL est également effectuée en local."
    ]
   },
   {
@@ -71,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 14,
    "id": "59e94172-c17e-4a12-9519-d1b26cd600df",
    "metadata": {},
    "outputs": [],
@@ -81,7 +73,6 @@
     "import json\n",
     "import pandas as pd\n",
     "import os\n",
-    "from datetime import datetime\n",
     "import hashlib\n",
     "from sqlalchemy import create_engine, text"
    ]
@@ -104,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 15,
    "id": "17e18cf1-1961-4200-9bb9-497ce803db59",
    "metadata": {},
    "outputs": [],
@@ -137,13 +128,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 16,
    "id": "8c47f4fc-a8ce-482c-ae6d-250061c5682d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# ---------------------------\n",
-    "# PARAMETRES DE RECHERCHE\n",
+    "# PARAMETRES\n",
     "# ---------------------------\n",
     "\n",
     "# Paramètres de recherche\n",
@@ -160,29 +151,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f8c2baf-0c81-4879-9cbb-7d3cad0f33a0",
-   "metadata": {},
-   "source": [
-    "### Paramètres de sauvegarde"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 125,
-   "id": "13daef8d-56fc-4538-994e-cecd5e78e67e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ---------------------------\n",
-    "# PARAMETRES DE SAUVEGARDE\n",
-    "# ---------------------------\n",
-    "# Répertoires\n",
-    "CSV_DIR = \"../data/csv\"\n",
-    "PARQUET_DIR = \"../data/parquet\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "59b50db3-037e-4050-b095-393fd8ca5aa1",
    "metadata": {},
    "source": [
@@ -191,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 17,
    "id": "5eb9b1d6-25f8-496c-8422-ba1185aee138",
    "metadata": {},
    "outputs": [],
@@ -222,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 18,
    "id": "e82e7838-3f2b-4058-95fe-465efefdbc5c",
    "metadata": {},
    "outputs": [],
@@ -283,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 19,
    "id": "86633fe9-b12a-4e55-9a0a-e63ccba9d994",
    "metadata": {},
    "outputs": [],
@@ -347,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 20,
    "id": "98da7cdb-9465-4684-957e-041bfe9c26a5",
    "metadata": {},
    "outputs": [],
@@ -377,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 21,
    "id": "ad547c1c-d524-4cad-8bbf-67afaafddb35",
    "metadata": {},
    "outputs": [],
@@ -415,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 22,
    "id": "77e3c4fc-d709-4a7e-bfb6-a32651541e7d",
    "metadata": {},
    "outputs": [],
@@ -435,58 +403,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd75112a-913c-4cc2-bdfd-f5a320ac2e9d",
-   "metadata": {},
-   "source": [
-    "### Sauvegarde CSV"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 132,
-   "id": "75d0bd1a-552d-4f1a-a5d5-6c71331c54cd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Sauvegarde Parquet ---\n",
-    "def save_to_csv(df):\n",
-    "    if df.empty:\n",
-    "        return\n",
-    "    os.makedirs(CSV_DIR, exist_ok=True)\n",
-    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "    path_csv = os.path.join(CSV_DIR, f\"{today}_offres.csv\")\n",
-    "    df.to_csv(path_csv, index=False,encoding=\"utf-8\")\n",
-    "    print(f\"✅ Sauvegardé dans {path_csv}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5e4c69b5-e661-49b9-be53-abe6835a3a74",
-   "metadata": {},
-   "source": [
-    "### Sauvegarde Parquet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 133,
-   "id": "0b972c51-3307-49aa-a409-21b662763b9f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Sauvegarde Parquet ---\n",
-    "def save_to_parquet(df):\n",
-    "    if df.empty:\n",
-    "        return\n",
-    "    os.makedirs(PARQUET_DIR, exist_ok=True)\n",
-    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "    path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
-    "    df.to_parquet(path_parquet, index=False)\n",
-    "    print(f\"✅ Sauvegardé dans {path_parquet}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "54cdda02-d6b6-40a2-bfac-934fc24cf646",
    "metadata": {},
    "source": [
@@ -495,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 23,
    "id": "fb6f8148-0086-47ea-b620-5d32c006c054",
    "metadata": {},
    "outputs": [],
@@ -524,16 +440,15 @@
     "\n",
     "    print(\"Affichage Extract offres France Travail...\")\n",
     "    df = pd.DataFrame(jobs_clean)\n",
+    "    display(df.shape)\n",
+    "    display(df.head(3))\n",
     "\n",
     "    # Export vers CSV\n",
-    "    print(\"💾 Sauvegarde en CSV...\")\n",
-    "    save_to_csv(df)\n",
-    "\n",
-    "    # Export vers Parquet\n",
-    "    print(\"💾 Sauvegarde en Parquet...\")\n",
-    "    save_to_parquet(df)\n",
+    "    path = \"../data/raw_data/\"\n",
+    "    file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
     "    \n",
-    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {CSV_DIR} et {PARQUET_DIR} ✅\")\n",
+    "    df.to_csv(path + file_name, index=False, encoding=\"utf-8\")\n",
+    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {file_name} ✅\")\n",
     "\n",
     "    # Connexion DB\n",
     "    print(\"Connexion à la base PostgreSQL...\")\n",
@@ -544,25 +459,22 @@
     "\n",
     "    print(\"💾 Sauvegarde en base PostgreSQL...\")\n",
     "    save_to_postgres(df, engine)\n",
-    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")\n",
-    "\n",
-    "    # Affichage extract offres\n",
-    "    display(df.shape)\n",
-    "    display(df.head(3))"
+    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 24,
    "id": "2de560b5-c04e-4118-9662-7069e1da4bf8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# # Chargement depuis CSV\n",
-    "# today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "# path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
-    "# df = pd.read_parquet(path_parquet)\n",
-    "# df.head()"
+    "# path = \"../data/raw_data/\"\n",
+    "# file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
+    "\n",
+    "# df = pd.read_csv(path+file_name)\n",
+    "# df.head(2)"
    ]
   },
   {
@@ -575,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 25,
    "id": "ff03fb25-913a-46ea-a784-b7f5f54e9f61",
    "metadata": {},
    "outputs": [
@@ -587,23 +499,15 @@
       "Récupération des offres France Travail...\n",
       "Récupération des offres Adzuna...\n",
       "Fusion et déduplication...\n",
-      "Nombre d'offres d'emploi avant déduplication : 1183\n",
-      "Nombre d'offres d'emploi après déduplication : 1181\n",
-      "Affichage Extract offres France Travail...\n",
-      "💾 Sauvegarde en CSV...\n",
-      "✅ Sauvegardé dans ../data/csv/2025-09-17_offres.csv\n",
-      "💾 Sauvegarde en Parquet...\n",
-      "✅ Sauvegardé dans ../data/parquet/2025-09-17_offres.parquet\n",
-      "1181 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
-      "Connexion à la base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
+      "Nombre d'offres d'emploi avant déduplication : 1185\n",
+      "Nombre d'offres d'emploi après déduplication : 1183\n",
+      "Affichage Extract offres France Travail...\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(1181, 12)"
+       "(1183, 12)"
       ]
      },
      "metadata": {},
@@ -648,21 +552,6 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>France Travail</td>\n",
-       "      <td>197XHCS</td>\n",
-       "      <td>DATA ANALYST/SCIENTIST(H/F)</td>\n",
-       "      <td>En tant que Data Analyst - Data Scientist, vou...</td>\n",
-       "      <td>INFOBAM</td>\n",
-       "      <td>972 - LE LAMENTIN</td>\n",
-       "      <td>14.615411</td>\n",
-       "      <td>-61.003361</td>\n",
-       "      <td>CDI</td>\n",
-       "      <td>2025-09-16T18:29:39.856Z</td>\n",
-       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
-       "      <td>Gestion d'installations informatiques</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>France Travail</td>\n",
        "      <td>197TNXM</td>\n",
        "      <td>Data Analyst ETL / SI Junior - H/F (H/F)</td>\n",
        "      <td>Empreinte est une société Française qui crée, ...</td>\n",
@@ -676,7 +565,7 @@
        "      <td>Fabrication de vêtements de dessous</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>1</th>\n",
        "      <td>France Travail</td>\n",
        "      <td>197NKZD</td>\n",
        "      <td>Consultant Data confirmé - Data Analyst H/F</td>\n",
@@ -690,30 +579,45 @@
        "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
        "      <td>Conseil en systèmes et logiciels informatiques</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>France Travail</td>\n",
+       "      <td>197PLRS</td>\n",
+       "      <td>Data Analyst (h/f)</td>\n",
+       "      <td>Adecco recherche pour l'un de ses clients, une...</td>\n",
+       "      <td>ADECCO FRANCE</td>\n",
+       "      <td>13 - Marignane</td>\n",
+       "      <td>43.407483</td>\n",
+       "      <td>5.255358</td>\n",
+       "      <td>Intérim - 12 Mois</td>\n",
+       "      <td>2025-09-09T16:27:22.779Z</td>\n",
+       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
+       "      <td>Activités des agences de travail temporaire</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "           Source       id                                        Titre  \\\n",
-       "0  France Travail  197XHCS                  DATA ANALYST/SCIENTIST(H/F)   \n",
-       "1  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
-       "2  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
+       "0  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
+       "1  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
+       "2  France Travail  197PLRS                           Data Analyst (h/f)   \n",
        "\n",
-       "                                         Description    Entreprise  \\\n",
-       "0  En tant que Data Analyst - Data Scientist, vou...       INFOBAM   \n",
-       "1  Empreinte est une société Française qui crée, ...  EMPREINTE SA   \n",
-       "2  Nous recherchons un(e) Consultant(e) Data conf...       EFFIDIC   \n",
+       "                                         Description     Entreprise  \\\n",
+       "0  Empreinte est une société Française qui crée, ...   EMPREINTE SA   \n",
+       "1  Nous recherchons un(e) Consultant(e) Data conf...        EFFIDIC   \n",
+       "2  Adecco recherche pour l'un de ses clients, une...  ADECCO FRANCE   \n",
        "\n",
-       "                Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
-       "0  972 - LE LAMENTIN  14.615411 -61.003361                  CDI   \n",
-       "1         29 - BREST  48.414003  -4.491985                  CDI   \n",
-       "2       49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
+       "             Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
+       "0      29 - BREST  48.414003  -4.491985                  CDI   \n",
+       "1    49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
+       "2  13 - Marignane  43.407483   5.255358    Intérim - 12 Mois   \n",
        "\n",
        "           Date_publication  \\\n",
-       "0  2025-09-16T18:29:39.856Z   \n",
-       "1  2025-09-12T17:46:57.887Z   \n",
-       "2  2025-09-09T09:24:40.097Z   \n",
+       "0  2025-09-12T17:46:57.887Z   \n",
+       "1  2025-09-09T09:24:40.097Z   \n",
+       "2  2025-09-09T16:27:22.779Z   \n",
        "\n",
        "                                                 URL  \\\n",
        "0  https://candidat.francetravail.fr/offres/reche...   \n",
@@ -721,13 +625,23 @@
        "2  https://candidat.francetravail.fr/offres/reche...   \n",
        "\n",
        "                                Secteur_activites  \n",
-       "0           Gestion d'installations informatiques  \n",
-       "1             Fabrication de vêtements de dessous  \n",
-       "2  Conseil en systèmes et logiciels informatiques  "
+       "0             Fabrication de vêtements de dessous  \n",
+       "1  Conseil en systèmes et logiciels informatiques  \n",
+       "2     Activités des agences de travail temporaire  "
       ]
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1183 offres uniques exportées dans offres_emploi_france_travail_adzuna.csv ✅\n",
+      "Connexion à la base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
+     ]
     }
    ],
    "source": [

--- a/notebooks/Connexion_France_Travail_ADZUNA_BACKUP.ipynb
+++ b/notebooks/Connexion_France_Travail_ADZUNA_BACKUP.ipynb
@@ -13,14 +13,7 @@
    "id": "0a6e368b-be9e-4195-b2ab-5f3eebcdcc12",
    "metadata": {},
    "source": [
-    "Ce script a pour objectif :\n",
-    "- d'extraire les offres d'emploi mises à disposition par :\n",
-    "  <br> _ l'API de **France Travail**\n",
-    "  <br>_ de l'API **ADZUNA**\n",
-    "- les stocker dans :\n",
-    "  <br> _ un fichier (**CSV**) en local\n",
-    "  <br> _ un fichier (**Parquet**) en local\n",
-    "  <br> _ dans une **BDD PostgreSQL** en local."
+    "Ce script a pour objectif d'extraire les offres d'emploi mises à disposition par l'API de France Travail et de l'API ADZUNA et de les stocker dans un fichier (CSV) en local ainsi qu'une sauvegarde dans une BDD PostgreSQL en local."
    ]
   },
   {
@@ -33,9 +26,8 @@
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API France Travail\n",
     "    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API Adzuna\n",
     "2. Une fois les offres trouvées, vérification et suppression des doublons.\n",
-    "3. Une sauvegarde en local des offres sont stockées dans un fichier (**CSV**).\n",
-    "4. Une sauvegarde en local des offres sont stockées dans un fichier (**Parquet**).\n",
-    "5. Une sauvegarde dans une base de données **PostgreSQL** est également effectuée en local."
+    "3. Une sauvegarde en local des offres sont stockées dans un fichier (CSV).\n",
+    "4. Une sauvegarde dans une base de données PostgreSQL est également effectuée en local."
    ]
   },
   {
@@ -71,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 14,
    "id": "59e94172-c17e-4a12-9519-d1b26cd600df",
    "metadata": {},
    "outputs": [],
@@ -81,7 +73,6 @@
     "import json\n",
     "import pandas as pd\n",
     "import os\n",
-    "from datetime import datetime\n",
     "import hashlib\n",
     "from sqlalchemy import create_engine, text"
    ]
@@ -104,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 15,
    "id": "17e18cf1-1961-4200-9bb9-497ce803db59",
    "metadata": {},
    "outputs": [],
@@ -137,13 +128,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 124,
+   "execution_count": 16,
    "id": "8c47f4fc-a8ce-482c-ae6d-250061c5682d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# ---------------------------\n",
-    "# PARAMETRES DE RECHERCHE\n",
+    "# PARAMETRES\n",
     "# ---------------------------\n",
     "\n",
     "# Paramètres de recherche\n",
@@ -160,29 +151,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1f8c2baf-0c81-4879-9cbb-7d3cad0f33a0",
-   "metadata": {},
-   "source": [
-    "### Paramètres de sauvegarde"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 125,
-   "id": "13daef8d-56fc-4538-994e-cecd5e78e67e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# ---------------------------\n",
-    "# PARAMETRES DE SAUVEGARDE\n",
-    "# ---------------------------\n",
-    "# Répertoires\n",
-    "CSV_DIR = \"../data/csv\"\n",
-    "PARQUET_DIR = \"../data/parquet\""
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "59b50db3-037e-4050-b095-393fd8ca5aa1",
    "metadata": {},
    "source": [
@@ -191,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 17,
    "id": "5eb9b1d6-25f8-496c-8422-ba1185aee138",
    "metadata": {},
    "outputs": [],
@@ -222,7 +190,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 127,
+   "execution_count": 18,
    "id": "e82e7838-3f2b-4058-95fe-465efefdbc5c",
    "metadata": {},
    "outputs": [],
@@ -283,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 128,
+   "execution_count": 19,
    "id": "86633fe9-b12a-4e55-9a0a-e63ccba9d994",
    "metadata": {},
    "outputs": [],
@@ -347,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 20,
    "id": "98da7cdb-9465-4684-957e-041bfe9c26a5",
    "metadata": {},
    "outputs": [],
@@ -377,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 21,
    "id": "ad547c1c-d524-4cad-8bbf-67afaafddb35",
    "metadata": {},
    "outputs": [],
@@ -415,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 131,
+   "execution_count": 22,
    "id": "77e3c4fc-d709-4a7e-bfb6-a32651541e7d",
    "metadata": {},
    "outputs": [],
@@ -435,58 +403,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd75112a-913c-4cc2-bdfd-f5a320ac2e9d",
-   "metadata": {},
-   "source": [
-    "### Sauvegarde CSV"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 132,
-   "id": "75d0bd1a-552d-4f1a-a5d5-6c71331c54cd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Sauvegarde Parquet ---\n",
-    "def save_to_csv(df):\n",
-    "    if df.empty:\n",
-    "        return\n",
-    "    os.makedirs(CSV_DIR, exist_ok=True)\n",
-    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "    path_csv = os.path.join(CSV_DIR, f\"{today}_offres.csv\")\n",
-    "    df.to_csv(path_csv, index=False,encoding=\"utf-8\")\n",
-    "    print(f\"✅ Sauvegardé dans {path_csv}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5e4c69b5-e661-49b9-be53-abe6835a3a74",
-   "metadata": {},
-   "source": [
-    "### Sauvegarde Parquet"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 133,
-   "id": "0b972c51-3307-49aa-a409-21b662763b9f",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# --- Sauvegarde Parquet ---\n",
-    "def save_to_parquet(df):\n",
-    "    if df.empty:\n",
-    "        return\n",
-    "    os.makedirs(PARQUET_DIR, exist_ok=True)\n",
-    "    today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "    path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
-    "    df.to_parquet(path_parquet, index=False)\n",
-    "    print(f\"✅ Sauvegardé dans {path_parquet}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "54cdda02-d6b6-40a2-bfac-934fc24cf646",
    "metadata": {},
    "source": [
@@ -495,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 134,
+   "execution_count": 23,
    "id": "fb6f8148-0086-47ea-b620-5d32c006c054",
    "metadata": {},
    "outputs": [],
@@ -524,16 +440,15 @@
     "\n",
     "    print(\"Affichage Extract offres France Travail...\")\n",
     "    df = pd.DataFrame(jobs_clean)\n",
+    "    display(df.shape)\n",
+    "    display(df.head(3))\n",
     "\n",
     "    # Export vers CSV\n",
-    "    print(\"💾 Sauvegarde en CSV...\")\n",
-    "    save_to_csv(df)\n",
-    "\n",
-    "    # Export vers Parquet\n",
-    "    print(\"💾 Sauvegarde en Parquet...\")\n",
-    "    save_to_parquet(df)\n",
+    "    path = \"../data/raw_data/\"\n",
+    "    file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
     "    \n",
-    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {CSV_DIR} et {PARQUET_DIR} ✅\")\n",
+    "    df.to_csv(path + file_name, index=False, encoding=\"utf-8\")\n",
+    "    print(f\"{len(jobs_clean)} offres uniques exportées dans {file_name} ✅\")\n",
     "\n",
     "    # Connexion DB\n",
     "    print(\"Connexion à la base PostgreSQL...\")\n",
@@ -544,25 +459,22 @@
     "\n",
     "    print(\"💾 Sauvegarde en base PostgreSQL...\")\n",
     "    save_to_postgres(df, engine)\n",
-    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")\n",
-    "\n",
-    "    # Affichage extract offres\n",
-    "    display(df.shape)\n",
-    "    display(df.head(3))"
+    "    print(\"💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 135,
+   "execution_count": 24,
    "id": "2de560b5-c04e-4118-9662-7069e1da4bf8",
    "metadata": {},
    "outputs": [],
    "source": [
     "# # Chargement depuis CSV\n",
-    "# today = datetime.now().strftime(\"%Y-%m-%d\")\n",
-    "# path_parquet = os.path.join(PARQUET_DIR, f\"{today}_offres.parquet\")\n",
-    "# df = pd.read_parquet(path_parquet)\n",
-    "# df.head()"
+    "# path = \"../data/raw_data/\"\n",
+    "# file_name = \"offres_emploi_france_travail_adzuna.csv\"\n",
+    "\n",
+    "# df = pd.read_csv(path+file_name)\n",
+    "# df.head(2)"
    ]
   },
   {
@@ -575,7 +487,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 136,
+   "execution_count": 25,
    "id": "ff03fb25-913a-46ea-a784-b7f5f54e9f61",
    "metadata": {},
    "outputs": [
@@ -587,23 +499,15 @@
       "Récupération des offres France Travail...\n",
       "Récupération des offres Adzuna...\n",
       "Fusion et déduplication...\n",
-      "Nombre d'offres d'emploi avant déduplication : 1183\n",
-      "Nombre d'offres d'emploi après déduplication : 1181\n",
-      "Affichage Extract offres France Travail...\n",
-      "💾 Sauvegarde en CSV...\n",
-      "✅ Sauvegardé dans ../data/csv/2025-09-17_offres.csv\n",
-      "💾 Sauvegarde en Parquet...\n",
-      "✅ Sauvegardé dans ../data/parquet/2025-09-17_offres.parquet\n",
-      "1181 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
-      "Connexion à la base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL...\n",
-      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
+      "Nombre d'offres d'emploi avant déduplication : 1185\n",
+      "Nombre d'offres d'emploi après déduplication : 1183\n",
+      "Affichage Extract offres France Travail...\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(1181, 12)"
+       "(1183, 12)"
       ]
      },
      "metadata": {},
@@ -648,21 +552,6 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>France Travail</td>\n",
-       "      <td>197XHCS</td>\n",
-       "      <td>DATA ANALYST/SCIENTIST(H/F)</td>\n",
-       "      <td>En tant que Data Analyst - Data Scientist, vou...</td>\n",
-       "      <td>INFOBAM</td>\n",
-       "      <td>972 - LE LAMENTIN</td>\n",
-       "      <td>14.615411</td>\n",
-       "      <td>-61.003361</td>\n",
-       "      <td>CDI</td>\n",
-       "      <td>2025-09-16T18:29:39.856Z</td>\n",
-       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
-       "      <td>Gestion d'installations informatiques</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>France Travail</td>\n",
        "      <td>197TNXM</td>\n",
        "      <td>Data Analyst ETL / SI Junior - H/F (H/F)</td>\n",
        "      <td>Empreinte est une société Française qui crée, ...</td>\n",
@@ -676,7 +565,7 @@
        "      <td>Fabrication de vêtements de dessous</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>1</th>\n",
        "      <td>France Travail</td>\n",
        "      <td>197NKZD</td>\n",
        "      <td>Consultant Data confirmé - Data Analyst H/F</td>\n",
@@ -690,30 +579,45 @@
        "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
        "      <td>Conseil en systèmes et logiciels informatiques</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>France Travail</td>\n",
+       "      <td>197PLRS</td>\n",
+       "      <td>Data Analyst (h/f)</td>\n",
+       "      <td>Adecco recherche pour l'un de ses clients, une...</td>\n",
+       "      <td>ADECCO FRANCE</td>\n",
+       "      <td>13 - Marignane</td>\n",
+       "      <td>43.407483</td>\n",
+       "      <td>5.255358</td>\n",
+       "      <td>Intérim - 12 Mois</td>\n",
+       "      <td>2025-09-09T16:27:22.779Z</td>\n",
+       "      <td>https://candidat.francetravail.fr/offres/reche...</td>\n",
+       "      <td>Activités des agences de travail temporaire</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
        "           Source       id                                        Titre  \\\n",
-       "0  France Travail  197XHCS                  DATA ANALYST/SCIENTIST(H/F)   \n",
-       "1  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
-       "2  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
+       "0  France Travail  197TNXM     Data Analyst ETL / SI Junior - H/F (H/F)   \n",
+       "1  France Travail  197NKZD  Consultant Data confirmé - Data Analyst H/F   \n",
+       "2  France Travail  197PLRS                           Data Analyst (h/f)   \n",
        "\n",
-       "                                         Description    Entreprise  \\\n",
-       "0  En tant que Data Analyst - Data Scientist, vou...       INFOBAM   \n",
-       "1  Empreinte est une société Française qui crée, ...  EMPREINTE SA   \n",
-       "2  Nous recherchons un(e) Consultant(e) Data conf...       EFFIDIC   \n",
+       "                                         Description     Entreprise  \\\n",
+       "0  Empreinte est une société Française qui crée, ...   EMPREINTE SA   \n",
+       "1  Nous recherchons un(e) Consultant(e) Data conf...        EFFIDIC   \n",
+       "2  Adecco recherche pour l'un de ses clients, une...  ADECCO FRANCE   \n",
        "\n",
-       "                Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
-       "0  972 - LE LAMENTIN  14.615411 -61.003361                  CDI   \n",
-       "1         29 - BREST  48.414003  -4.491985                  CDI   \n",
-       "2       49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
+       "             Lieu   Latitude  Longitude type_Contrat_Libelle  \\\n",
+       "0      29 - BREST  48.414003  -4.491985                  CDI   \n",
+       "1    49 - TRELAZE  47.445931  -0.466974                  CDI   \n",
+       "2  13 - Marignane  43.407483   5.255358    Intérim - 12 Mois   \n",
        "\n",
        "           Date_publication  \\\n",
-       "0  2025-09-16T18:29:39.856Z   \n",
-       "1  2025-09-12T17:46:57.887Z   \n",
-       "2  2025-09-09T09:24:40.097Z   \n",
+       "0  2025-09-12T17:46:57.887Z   \n",
+       "1  2025-09-09T09:24:40.097Z   \n",
+       "2  2025-09-09T16:27:22.779Z   \n",
        "\n",
        "                                                 URL  \\\n",
        "0  https://candidat.francetravail.fr/offres/reche...   \n",
@@ -721,13 +625,23 @@
        "2  https://candidat.francetravail.fr/offres/reche...   \n",
        "\n",
        "                                Secteur_activites  \n",
-       "0           Gestion d'installations informatiques  \n",
-       "1             Fabrication de vêtements de dessous  \n",
-       "2  Conseil en systèmes et logiciels informatiques  "
+       "0             Fabrication de vêtements de dessous  \n",
+       "1  Conseil en systèmes et logiciels informatiques  \n",
+       "2     Activités des agences de travail temporaire  "
       ]
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1183 offres uniques exportées dans offres_emploi_france_travail_adzuna.csv ✅\n",
+      "Connexion à la base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL...\n",
+      "💾 Sauvegarde en base PostgreSQL TERMINEE !!!...\n"
+     ]
     }
    ],
    "source": [


### PR DESCRIPTION
Ce script a pour objectif :
- d'extraire les offres d'emploi mises à disposition par :
  _ l'API de **France Travail**
  <br>_ de l'API **ADZUNA**
- les stocker dans :
  <br> _ un fichier (**CSV**) en local
  <br> _ un fichier (**Parquet**) en local
  <br> _ dans une **BDD PostgreSQL** en local.

Comment ?
1. Sur la base de critères spécifiques (mots clés, localisation, etc...), 
    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API France Travail
    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API Adzuna
2. Une fois les offres trouvées, vérification et suppression des doublons.
3. Une sauvegarde en local des offres sont stockées dans un fichier (**CSV**).
4. Une sauvegarde en local des offres sont stockées dans un fichier (**Parquet**).
5. Une sauvegarde dans une base de données **PostgreSQL** est également effectuée en local.