### PR TITLE
fetch_error_handling ok

### DIFF
--- a/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/Connexion_France_Travail_ADZUNA-checkpoint.ipynb
@@ -23,7 +23,7 @@
     "  <br> _ dans une **BDD PostgreSQL** en local.\n",
     "\n",
     "**/!\\ Ajouts !** : \n",
-    "- on conflict DO UPDATE"
+    "- Gestion des valeurs manquantes lors des requêtes API"
    ]
   },
   {
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 65,
    "id": "59e94172-c17e-4a12-9519-d1b26cd600df",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 66,
    "id": "17e18cf1-1961-4200-9bb9-497ce803db59",
    "metadata": {},
    "outputs": [],
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 67,
    "id": "ca4800b7-7129-4eb8-96ac-67c77a532e10",
    "metadata": {},
    "outputs": [],
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 68,
    "id": "8c47f4fc-a8ce-482c-ae6d-250061c5682d",
    "metadata": {},
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 69,
    "id": "13daef8d-56fc-4538-994e-cecd5e78e67e",
    "metadata": {},
    "outputs": [],
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 70,
    "id": "5eb9b1d6-25f8-496c-8422-ba1185aee138",
    "metadata": {},
    "outputs": [],
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 71,
    "id": "e82e7838-3f2b-4058-95fe-465efefdbc5c",
    "metadata": {},
    "outputs": [],
@@ -281,17 +281,17 @@
     "            for o in offres:\n",
     "                all_jobs.append({\n",
     "                    \"source\": \"France Travail\",\n",
-    "                    \"id\":o.get(\"id\"),    \n",
-    "                    \"titre\": o.get(\"intitule\"),\n",
-    "                    \"description\": o.get(\"description\"),\n",
-    "                    \"entreprise\": o.get(\"entreprise\", {}).get(\"nom\"),\n",
-    "                    \"lieu\": o.get(\"lieuTravail\", {}).get(\"libelle\"),\n",
-    "                    \"latitude\": o.get(\"lieuTravail\", {}).get(\"latitude\"),\n",
-    "                    \"longitude\": o.get(\"lieuTravail\", {}).get(\"longitude\"),\n",
-    "                    \"type_contrat_libelle\": o.get(\"typeContratLibelle\"),\n",
-    "                    \"date_publication\": o.get(\"dateCreation\"),\n",
+    "                    \"id\":o.get(\"id\") if o.get(\"id\") is not None else \"None\",    \n",
+    "                    \"titre\": o.get(\"intitule\") if o.get(\"intitule\") is not None else \"None\",                     \n",
+    "                    \"description\": o.get(\"description\") if o.get(\"description\") is not None else \"None\", \n",
+    "                    \"entreprise\": o.get(\"entreprise\", {}).get(\"nom\") if o.get(\"entreprise\", {}).get(\"nom\") is not None else \"None\", \n",
+    "                    \"lieu\": o.get(\"lieuTravail\", {}).get(\"libelle\") if o.get(\"lieuTravail\", {}).get(\"libelle\") is not None else \"None\", \n",
+    "                    \"latitude\": o.get(\"lieuTravail\", {}).get(\"latitude\") if o.get(\"lieuTravail\", {}) is not None else \"None\", \n",
+    "                    \"longitude\": o.get(\"lieuTravail\", {}).get(\"longitude\") if o.get(\"lieuTravail\", {}) is not None else \"None\", \n",
+    "                    \"type_contrat_libelle\": o.get(\"typeContratLibelle\") if o.get(\"typeContratLibelle\") is not None else \"None\", \n",
+    "                    \"date_publication\": o.get(\"dateCreation\") if o.get(\"dateCreation\") is not None else \"None\",    \n",
     "                    \"url\": o.get(\"origineOffre\").get(\"urlOrigine\") if o.get(\"origineOffre\") is not None else \"None\",\n",
-    "                    \"secteur_activites\": o.get(\"secteurActiviteLibelle\"),\n",
+    "                    \"secteur_activites\": o.get(\"secteurActiviteLibelle\") if o.get(\"dateCreation\") is not None else \"None\"\n",
     "                })\n",
     "            # print(len(offres))\n",
     "\n",
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 72,
    "id": "86633fe9-b12a-4e55-9a0a-e63ccba9d994",
    "metadata": {},
    "outputs": [],
@@ -346,16 +346,16 @@
     "            for o in offres:\n",
     "                all_jobs.append({\n",
     "                    \"source\": \"Adzuna\",\n",
-    "                    \"id\" : o.get(\"id\"),\n",
-    "                    \"titre\" : o.get(\"title\"),\n",
-    "                    \"description\" : o.get(\"description\"),\n",
+    "                    \"id\" : o.get(\"id\") if o.get(\"id\") is not None else \"None\", \n",
+    "                    \"titre\" : o.get(\"title\") if o.get(\"title\") is not None else \"None\", \n",
+    "                    \"description\" : o.get(\"description\") if o.get(\"description\") is not None else \"None\", \n",
     "                    \"entreprise\": o.get(\"company\").get(\"display_name\") if o.get(\"company\") is not None else \"None\",\n",
-    "                    \"lieu\" : o.get(\"location\").get(\"display_name\") if o.get(\"location\") is not None else \"None\",  \n",
-    "                    \"latitude\" : o.get(\"latitude\"),\n",
-    "                    \"longitude\" : o.get(\"longitude\"),\n",
-    "                    \"type_contrat_libelle\" : o.get(\"contract_type\"),                    \n",
-    "                    \"date_publication\" : o.get(\"created\"),\n",
-    "                    \"url\" : o.get(\"redirect_url\"),\n",
+    "                    \"lieu\" : o.get(\"location\").get(\"display_name\") if o.get(\"location\") is not None else \"None\",    \n",
+    "                    \"latitude\" : o.get(\"latitude\") if o.get(\"latitude\") is not None else \"None\", \n",
+    "                    \"longitude\" : o.get(\"longitude\") if o.get(\"longitude\") is not None else \"None\",\n",
+    "                    \"type_contrat_libelle\" : o.get(\"contract_type\") if o.get(\"contract_type\") is not None else \"None\",                \n",
+    "                    \"date_publication\" : o.get(\"created\") if o.get(\"created\") is not None else \"None\",  \n",
+    "                    \"url\" : o.get(\"redirect_url\") if o.get(\"redirect_url\") is not None else \"None\",  \n",
     "                    \"secteur_activites\" : o.get(\"category\").get(\"label\") if o.get(\"category\") is not None else \"None\",\n",
     "                })\n",
     "                \n",
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 73,
    "id": "98da7cdb-9465-4684-957e-041bfe9c26a5",
    "metadata": {},
    "outputs": [],
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 74,
    "id": "ad547c1c-d524-4cad-8bbf-67afaafddb35",
    "metadata": {},
    "outputs": [],
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 75,
    "id": "e4f8714f-8ab5-43c6-8e03-98bce597c784",
    "metadata": {},
    "outputs": [],
@@ -525,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 76,
    "id": "75d0bd1a-552d-4f1a-a5d5-6c71331c54cd",
    "metadata": {},
    "outputs": [],
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 77,
    "id": "0b972c51-3307-49aa-a409-21b662763b9f",
    "metadata": {},
    "outputs": [],
@@ -577,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 78,
    "id": "fb6f8148-0086-47ea-b620-5d32c006c054",
    "metadata": {},
    "outputs": [],
@@ -635,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 79,
    "id": "2de560b5-c04e-4118-9662-7069e1da4bf8",
    "metadata": {},
    "outputs": [],
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 80,
    "id": "ff03fb25-913a-46ea-a784-b7f5f54e9f61",
    "metadata": {},
    "outputs": [
@@ -670,14 +670,14 @@
       "Récupération des offres France Travail...\n",
       "Récupération des offres Adzuna...\n",
       "Fusion et déduplication...\n",
-      "Nombre d'offres d'emploi avant déduplication : 1188\n",
-      "Nombre d'offres d'emploi après déduplication : 1186\n",
+      "Nombre d'offres d'emploi avant déduplication : 1190\n",
+      "Nombre d'offres d'emploi après déduplication : 1188\n",
       "Affichage Extract offres France Travail...\n",
       "💾 Sauvegarde en CSV...\n",
       "✅ Sauvegardé dans ../data/csv/2025-09-17_offres.csv\n",
       "💾 Sauvegarde en Parquet...\n",
       "✅ Sauvegardé dans ../data/parquet/2025-09-17_offres.parquet\n",
-      "1186 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
+      "1188 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
       "Connexion à la base PostgreSQL...\n",
       "💾 Sauvegarde en base PostgreSQL...\n"
      ]
@@ -686,7 +686,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-09-17 09:32:45,390 - INFO - ✅ 1186 lignes insérées ou mises à jour dans 'offres' (last_updated=2025-09-17 07:32:45.107704).\n"
+      "2025-09-17 10:09:10,272 - INFO - ✅ 1188 lignes insérées ou mises à jour dans 'offres' (last_updated=2025-09-17 08:09:09.948724).\n"
      ]
     },
     {
@@ -699,7 +699,7 @@
     {
      "data": {
       "text/plain": [
-       "(1186, 12)"
+       "(1188, 12)"
       ]
      },
      "metadata": {},

--- a/notebooks/Connexion_France_Travail_ADZUNA.ipynb
+++ b/notebooks/Connexion_France_Travail_ADZUNA.ipynb
@@ -23,7 +23,7 @@
     "  <br> _ dans une **BDD PostgreSQL** en local.\n",
     "\n",
     "**/!\\ Ajouts !** : \n",
-    "- on conflict DO UPDATE"
+    "- Gestion des valeurs manquantes lors des requêtes API"
    ]
   },
   {
@@ -74,7 +74,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 65,
    "id": "59e94172-c17e-4a12-9519-d1b26cd600df",
    "metadata": {},
    "outputs": [],
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 66,
    "id": "17e18cf1-1961-4200-9bb9-497ce803db59",
    "metadata": {},
    "outputs": [],
@@ -147,7 +147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 67,
    "id": "ca4800b7-7129-4eb8-96ac-67c77a532e10",
    "metadata": {},
    "outputs": [],
@@ -166,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 68,
    "id": "8c47f4fc-a8ce-482c-ae6d-250061c5682d",
    "metadata": {},
    "outputs": [],
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 69,
    "id": "13daef8d-56fc-4538-994e-cecd5e78e67e",
    "metadata": {},
    "outputs": [],
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 70,
    "id": "5eb9b1d6-25f8-496c-8422-ba1185aee138",
    "metadata": {},
    "outputs": [],
@@ -251,7 +251,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 71,
    "id": "e82e7838-3f2b-4058-95fe-465efefdbc5c",
    "metadata": {},
    "outputs": [],
@@ -281,17 +281,17 @@
     "            for o in offres:\n",
     "                all_jobs.append({\n",
     "                    \"source\": \"France Travail\",\n",
-    "                    \"id\":o.get(\"id\"),    \n",
-    "                    \"titre\": o.get(\"intitule\"),\n",
-    "                    \"description\": o.get(\"description\"),\n",
-    "                    \"entreprise\": o.get(\"entreprise\", {}).get(\"nom\"),\n",
-    "                    \"lieu\": o.get(\"lieuTravail\", {}).get(\"libelle\"),\n",
-    "                    \"latitude\": o.get(\"lieuTravail\", {}).get(\"latitude\"),\n",
-    "                    \"longitude\": o.get(\"lieuTravail\", {}).get(\"longitude\"),\n",
-    "                    \"type_contrat_libelle\": o.get(\"typeContratLibelle\"),\n",
-    "                    \"date_publication\": o.get(\"dateCreation\"),\n",
+    "                    \"id\":o.get(\"id\") if o.get(\"id\") is not None else \"None\",    \n",
+    "                    \"titre\": o.get(\"intitule\") if o.get(\"intitule\") is not None else \"None\",                     \n",
+    "                    \"description\": o.get(\"description\") if o.get(\"description\") is not None else \"None\", \n",
+    "                    \"entreprise\": o.get(\"entreprise\", {}).get(\"nom\") if o.get(\"entreprise\", {}).get(\"nom\") is not None else \"None\", \n",
+    "                    \"lieu\": o.get(\"lieuTravail\", {}).get(\"libelle\") if o.get(\"lieuTravail\", {}).get(\"libelle\") is not None else \"None\", \n",
+    "                    \"latitude\": o.get(\"lieuTravail\", {}).get(\"latitude\") if o.get(\"lieuTravail\", {}) is not None else \"None\", \n",
+    "                    \"longitude\": o.get(\"lieuTravail\", {}).get(\"longitude\") if o.get(\"lieuTravail\", {}) is not None else \"None\", \n",
+    "                    \"type_contrat_libelle\": o.get(\"typeContratLibelle\") if o.get(\"typeContratLibelle\") is not None else \"None\", \n",
+    "                    \"date_publication\": o.get(\"dateCreation\") if o.get(\"dateCreation\") is not None else \"None\",    \n",
     "                    \"url\": o.get(\"origineOffre\").get(\"urlOrigine\") if o.get(\"origineOffre\") is not None else \"None\",\n",
-    "                    \"secteur_activites\": o.get(\"secteurActiviteLibelle\"),\n",
+    "                    \"secteur_activites\": o.get(\"secteurActiviteLibelle\") if o.get(\"dateCreation\") is not None else \"None\"\n",
     "                })\n",
     "            # print(len(offres))\n",
     "\n",
@@ -312,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 72,
    "id": "86633fe9-b12a-4e55-9a0a-e63ccba9d994",
    "metadata": {},
    "outputs": [],
@@ -346,16 +346,16 @@
     "            for o in offres:\n",
     "                all_jobs.append({\n",
     "                    \"source\": \"Adzuna\",\n",
-    "                    \"id\" : o.get(\"id\"),\n",
-    "                    \"titre\" : o.get(\"title\"),\n",
-    "                    \"description\" : o.get(\"description\"),\n",
+    "                    \"id\" : o.get(\"id\") if o.get(\"id\") is not None else \"None\", \n",
+    "                    \"titre\" : o.get(\"title\") if o.get(\"title\") is not None else \"None\", \n",
+    "                    \"description\" : o.get(\"description\") if o.get(\"description\") is not None else \"None\", \n",
     "                    \"entreprise\": o.get(\"company\").get(\"display_name\") if o.get(\"company\") is not None else \"None\",\n",
-    "                    \"lieu\" : o.get(\"location\").get(\"display_name\") if o.get(\"location\") is not None else \"None\",  \n",
-    "                    \"latitude\" : o.get(\"latitude\"),\n",
-    "                    \"longitude\" : o.get(\"longitude\"),\n",
-    "                    \"type_contrat_libelle\" : o.get(\"contract_type\"),                    \n",
-    "                    \"date_publication\" : o.get(\"created\"),\n",
-    "                    \"url\" : o.get(\"redirect_url\"),\n",
+    "                    \"lieu\" : o.get(\"location\").get(\"display_name\") if o.get(\"location\") is not None else \"None\",    \n",
+    "                    \"latitude\" : o.get(\"latitude\") if o.get(\"latitude\") is not None else \"None\", \n",
+    "                    \"longitude\" : o.get(\"longitude\") if o.get(\"longitude\") is not None else \"None\",\n",
+    "                    \"type_contrat_libelle\" : o.get(\"contract_type\") if o.get(\"contract_type\") is not None else \"None\",                \n",
+    "                    \"date_publication\" : o.get(\"created\") if o.get(\"created\") is not None else \"None\",  \n",
+    "                    \"url\" : o.get(\"redirect_url\") if o.get(\"redirect_url\") is not None else \"None\",  \n",
     "                    \"secteur_activites\" : o.get(\"category\").get(\"label\") if o.get(\"category\") is not None else \"None\",\n",
     "                })\n",
     "                \n",
@@ -376,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 73,
    "id": "98da7cdb-9465-4684-957e-041bfe9c26a5",
    "metadata": {},
    "outputs": [],
@@ -406,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 74,
    "id": "ad547c1c-d524-4cad-8bbf-67afaafddb35",
    "metadata": {},
    "outputs": [],
@@ -444,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 75,
    "id": "e4f8714f-8ab5-43c6-8e03-98bce597c784",
    "metadata": {},
    "outputs": [],
@@ -525,7 +525,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 76,
    "id": "75d0bd1a-552d-4f1a-a5d5-6c71331c54cd",
    "metadata": {},
    "outputs": [],
@@ -551,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 77,
    "id": "0b972c51-3307-49aa-a409-21b662763b9f",
    "metadata": {},
    "outputs": [],
@@ -577,7 +577,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 78,
    "id": "fb6f8148-0086-47ea-b620-5d32c006c054",
    "metadata": {},
    "outputs": [],
@@ -635,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 79,
    "id": "2de560b5-c04e-4118-9662-7069e1da4bf8",
    "metadata": {},
    "outputs": [],
@@ -658,7 +658,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 80,
    "id": "ff03fb25-913a-46ea-a784-b7f5f54e9f61",
    "metadata": {},
    "outputs": [
@@ -670,14 +670,14 @@
       "Récupération des offres France Travail...\n",
       "Récupération des offres Adzuna...\n",
       "Fusion et déduplication...\n",
-      "Nombre d'offres d'emploi avant déduplication : 1188\n",
-      "Nombre d'offres d'emploi après déduplication : 1186\n",
+      "Nombre d'offres d'emploi avant déduplication : 1190\n",
+      "Nombre d'offres d'emploi après déduplication : 1188\n",
       "Affichage Extract offres France Travail...\n",
       "💾 Sauvegarde en CSV...\n",
       "✅ Sauvegardé dans ../data/csv/2025-09-17_offres.csv\n",
       "💾 Sauvegarde en Parquet...\n",
       "✅ Sauvegardé dans ../data/parquet/2025-09-17_offres.parquet\n",
-      "1186 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
+      "1188 offres uniques exportées dans ../data/csv et ../data/parquet ✅\n",
       "Connexion à la base PostgreSQL...\n",
       "💾 Sauvegarde en base PostgreSQL...\n"
      ]
@@ -686,7 +686,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2025-09-17 09:32:45,390 - INFO - ✅ 1186 lignes insérées ou mises à jour dans 'offres' (last_updated=2025-09-17 07:32:45.107704).\n"
+      "2025-09-17 10:09:10,272 - INFO - ✅ 1188 lignes insérées ou mises à jour dans 'offres' (last_updated=2025-09-17 08:09:09.948724).\n"
      ]
     },
     {
@@ -699,7 +699,7 @@
     {
      "data": {
       "text/plain": [
-       "(1186, 12)"
+       "(1188, 12)"
       ]
      },
      "metadata": {},


### PR DESCRIPTION
Ce script a pour objectif :
- d'extraire les offres d'emploi mises à disposition par :
  _ l'API de **France Travail**
  _ de l'API **ADZUNA**
- les stocker dans :
  _ un fichier (**CSV**) en local
  _ un fichier (**Parquet**) en local
  _ dans une **BDD PostgreSQL** en local.

**/!\ Ajouts !** : 
- Gestion des valeurs manquantes lors des requêtes API

Comment ?
1. Sur la base de critères spécifiques (mots clés, localisation, etc...), 
    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API France Travail
    - lancement d'une requête pour obtenir les offres d'emploi correspondantes via l'API Adzuna
2. Une fois les offres trouvées, vérification et suppression des doublons.
3. Une sauvegarde en local des offres sont stockées dans un fichier (**CSV**).
4. Une sauvegarde en local des offres sont stockées dans un fichier (**Parquet**).
5. Une sauvegarde dans une base de données **PostgreSQL** est également effectuée en local.